### PR TITLE
Add a clear warning about spaces in the update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ to the update request provided:
 
 The only required key is "url", the others are optional.
 
+**Please note!** Due to an [open issue](https://github.com/Squirrel/Squirrel.Windows/issues/414) in Squirrel,
+you must be careful if the URL contains spaces. For the time being, it's easiest
+just to remove all spaces from the URL.
+
 Squirrel will request "url" with `Accept: application/zip` and only supports
 installing ZIP updates. If future update formats are supported their MIME type
 will be added to the `Accept` header so that your server can return the


### PR DESCRIPTION
I just spent several days trying to figure out why Squirrel wasn't updating, even though everything seemed to be set up correctly. When I finally tried removing the space from the file name, the update worked. While this issue is open, it should be clearly called out in the documentation.

I didn't see an issue in the Mac section of the project, so I linked to the Windows one.
